### PR TITLE
アクセシビリティ向上のためmainランドマークを追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,31 +1,27 @@
-import type { Metadata } from 'next';
-import { Raleway } from 'next/font/google';
-import Header from '../components/Header';
-import './globals.css';
+import type { Metadata } from "next";
+import { Raleway } from "next/font/google";
+import Header from "../components/Header";
+import "./globals.css";
 
 const raleway = Raleway({
-  weight: ['400', '700'],
-  style: ['normal'],
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-raleway',
+  weight: ["400", "700"],
+  style: ["normal"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-raleway",
 });
 
 export const metadata: Metadata = {
-  title: 'TinyKitten',
-  description: 'フルスタッククリエイター TinyKittenのポートフォリオです。',
+  title: "TinyKitten",
+  description: "フルスタッククリエイター TinyKittenのポートフォリオです。",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className={raleway.variable}>
       <body className={raleway.className}>
         <Header />
-        {children}
+        <main>{children}</main>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- PageSpeedのa11y指摘に対応し、`app/layout.tsx`に`<main>`ランドマーク要素を追加
- スクリーンリーダー等の支援技術がメインコンテンツ領域を正しく認識できるように

## Test plan
- [ ] PageSpeed Insightsでa11yスコアが改善されていることを確認
- [ ] スクリーンリーダーでメインランドマークが認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ページレイアウト構造を更新しました。コード形式を統一し、内部最適化を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->